### PR TITLE
[ci skip] adding user @matthiasdv

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
 * @ian-r-rose @jrbourbeau @mrocklin @necaris
+* @matthiasdv

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -61,6 +61,7 @@ about:
 
 extra:
   recipe-maintainers:
+    - matthiasdv
     - jrbourbeau
     - mrocklin
     - ian-r-rose


### PR DESCRIPTION

Hi! This is the friendly automated conda-forge-webservice.

I've added user @matthiasdv as instructed in #50.

Merge this PR to add the user. Please do not rerender this PR or change it in any way. It has `[ci skip]` in the commit message to avoid pushing a new build and so the build configuration in the feedstock should not be changed.

Fixes #50