### PR TITLE
Don't lock to an old version of Dask

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,7 +28,7 @@ requirements:
     - backoff >=1.10.0
     - boto3
     - click >=7.1
-    - dask >=2.23.0,<2021.12.0
+    - dask >=2.23.0
     - s3fs
     - pandas >=1.1.0
     - ipython


### PR DESCRIPTION
This is causing all kinds of weird solves, using old versions of `dask` (e.g. `2021.10.0`). 